### PR TITLE
[FEAT] ServiceWorker 등록, 오프라인 fallback 페이지 적용

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -32,6 +32,11 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>단통</title>
+    <script>
+      if (typeof navigator.serviceWorker !== 'undefined') {
+        navigator.serviceWorker.register('sw.js')
+      }
+    </script>
     <script type="module">
       import 'https://cdn.jsdelivr.net/npm/@pwabuilder/pwaupdate';
       const el = document.createElement('pwa-update');

--- a/public/pwabuilder-sw.js
+++ b/public/pwabuilder-sw.js
@@ -4,8 +4,7 @@ importScripts('https://storage.googleapis.com/workbox-cdn/releases/5.1.2/workbox
 
 const CACHE = "pwabuilder-page";
 
-// TODO: replace the following with the correct offline fallback page i.e.: const offlineFallbackPage = "offline.html";
-const offlineFallbackPage = "ToDo-replace-this-name.html";
+const offlineFallbackPage = "offline.html";
 
 self.addEventListener("message", (event) => {
   if (event.data && event.data.type === "SKIP_WAITING") {
@@ -45,5 +44,3 @@ self.addEventListener('fetch', (event) => {
     })());
   }
 });
-
-const offlineFallbackPage = 'offline.html';

--- a/public/sw.js
+++ b/public/sw.js
@@ -19,15 +19,12 @@ self.addEventListener('activate', (event) => {
   event.waitUntil(self.clients.claim());
 });
 
-    registration.showNotification('Hello!', {
-      body: 'This is a push notification!',
-    }),
-      self.addEventListener('push', () => {
-        event.waitUntil(
-          registration.showNotification('Hello!', {
-            body: 'This is a push notification!',
-          }),
-        );
-      });
+self.addEventListener('push', () => {
+    event.waitUntil(
+        registration.showNotification('Hello!', {
+        body: 'This is a push notification!',
+        }),
+    );
+});
 
 workbox.precaching.precacheAndRoute(self.__WB_MANIFEST || []);

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,33 @@
+importScripts(
+  'https://storage.googleapis.com/workbox-cdn/releases/6.5.4/workbox-sw.js',
+);
+
+const CACHE_NAME = 'cache';
+
+const PRECACHE_ASSETS = ['/assets/', '/src/'];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    (async () => {
+      const cache = await caches.open(CACHE_NAME);
+      cache.addAll(PRECACHE_ASSETS);
+    })(),
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+    registration.showNotification('Hello!', {
+      body: 'This is a push notification!',
+    }),
+      self.addEventListener('push', () => {
+        event.waitUntil(
+          registration.showNotification('Hello!', {
+            body: 'This is a push notification!',
+          }),
+        );
+      });
+
+workbox.precaching.precacheAndRoute(self.__WB_MANIFEST || []);


### PR DESCRIPTION
## 📝  What is this PR?
SerivceWorker가 등록되지 않는 이슈(#1)에 대한 PR입니다.
`ServiceWorker`을 전역에 등록하였으며, PWA의 캐싱 기능을 편하게 구현할 수 있는 표준 PWA 라이브러리인 `workbox`를 통하여 오프라인의 경우 캐싱된 페이지 또는 오프라인 fallback 페이지가 나타나도록 하였습니다.

## ✅ Changes
아래의 스크립트를 `public/index.html`에 작성하여 ServiceWorker가 애플리케이션 전체를 접근할 수 있도록 하였습니다.
ServiceWorker의 작업 내용을 포함한 `sw.js`는 같은 디렉토리에 배치하였습니다.
```javascript
<script>
  if (typeof navigator.serviceWorker !== 'undefined') {
    navigator.serviceWorker.register('sw.js')
  }
</script>
```
<br/>

import된 https://cdn.jsdelivr.net/npm/@pwabuilder/pwaupdate 소스 내용을 분석하며 오프라인 처리 스크립트인 `pwabuilder-sw.js`를 해당 스크립트가 작성된 파일의 같은 디렉토리에 위치시켜야 한다는 것을 깨달았고, `pwabuilder-sw.js`를 public 디렉토리로 옮겼습니다.

```javascript
    <script type="module">
      import 'https://cdn.jsdelivr.net/npm/@pwabuilder/pwaupdate';
      const el = document.createElement('pwa-update');
      document.body.appendChild(el);
    </script>
```
<br/>

`sw.js`에 아래의 코드를 작성하여 푸쉬 알림이 알맞게 뜨는 것을 확인하였습니다.
``` javascript
        registration.showNotification('Hello!', {
        body: 'This is a push notification!',
        }),
```

![Untitled (1)](https://github.com/user-attachments/assets/bbcb5eeb-c9f1-4c56-9544-91891f422c65)