### PR TITLE
[FEAT] 메인 포스트 Skeleton 적용

### DIFF
--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -2,7 +2,7 @@ import { HTMLAttributes, ReactNode } from 'react';
 import { handleCustomCSS } from '../utils/handleCustomCSS';
 
 type Box = HTMLAttributes<HTMLDivElement> & {
-  children: ReactNode;
+  children?: ReactNode;
   className?: string;
 };
 

--- a/src/layout/FallbackLayout.tsx
+++ b/src/layout/FallbackLayout.tsx
@@ -1,10 +1,9 @@
 import { Outlet } from 'react-router-dom';
-import { Loader } from '../components/Loader';
 import { Suspense } from 'react';
 
 export const FallbackLayout = () => (
   <div className="flex h-full w-full flex-col justify-center">
-    <Suspense fallback={<Loader type="clip" />}>
+    <Suspense>
       <Outlet />
     </Suspense>
   </div>

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -4,7 +4,6 @@ import { Outlet, useLocation } from 'react-router-dom';
 import { Suspense, useEffect, useRef } from 'react';
 import { useTopBarStore } from '../stores/topBar-stores';
 import { Axios } from '../components/Axios';
-import { Loader } from '../components/Loader';
 
 export const Layout = ({ className }: { className?: string }) => {
   const layoutRef = useRef<HTMLDivElement>(null);
@@ -30,7 +29,7 @@ export const Layout = ({ className }: { className?: string }) => {
         ref={layoutRef}
         className={`flex w-full flex-col overflow-auto bg-[#EBF4FF] px-5 pb-[100px] pt-[60px] ${className}`}
       >
-        <Suspense fallback={<Loader type="clip" />}>
+        <Suspense>
           <Outlet />
         </Suspense>
       </div>

--- a/src/pages/index/PostItem.tsx
+++ b/src/pages/index/PostItem.tsx
@@ -16,14 +16,14 @@ export const PostItem = ({
       onClick={() => {
         navigate(`/news/${postId}`);
       }}
-      className="h-[17rem] w-[17rem] cursor-pointer flex-col overflow-hidden p-0"
+      className={`skeleton_loading h-[17rem] w-[17rem] cursor-pointer flex-col overflow-hidden p-0`}
     >
       <div
-        className="h-[17rem] bg-slate-300 bg-cover"
+        className="h-[17rem] bg-[#e5e5e5] bg-cover"
         style={{
-          backgroundImage: `url(${postFileResponse[0]?.url})` ?? '',
+          backgroundImage: `url(${postFileResponse[0]?.url ?? ''})`,
         }}
-      ></div>
+      />
       <div className="box-border flex h-[4rem] items-center gap-2 bg-white p-2">
         <img
           className="h-[2rem] w-[2rem] rounded-full border-[1px] border-solid border-[#e7e7e7]"
@@ -31,7 +31,7 @@ export const PostItem = ({
           alt="학생회 로고"
         />
         <div className="flex w-[calc(100%-2.8rem)] flex-col gap-[0.1rem]">
-          <p className="w-full overflow-hidden text-ellipsis whitespace-nowrap text-sm ">
+          <p className="w-full overflow-hidden text-ellipsis whitespace-nowrap text-sm">
             {title}
           </p>
           <p className="text-xs text-[#848484]">SW융합대학 SW:ing 학생회</p>

--- a/src/pages/index/PostItemList.tsx
+++ b/src/pages/index/PostItemList.tsx
@@ -1,0 +1,19 @@
+import { SwiperSlide } from 'swiper/react';
+import HorizontalScrollBox from '../../components/HorizontalScrollBox';
+import { PostItem } from './PostItem';
+import { useGetPostList } from '../../query-hooks/post';
+import { PostDetailResponse } from '../../api/post/types';
+
+export default function PostItemList() {
+  const { data: postList } = useGetPostList('');
+
+  return (
+    <HorizontalScrollBox>
+      {postList?.content.map((postData: PostDetailResponse) => (
+        <SwiperSlide key={`post-${postData.postId}`}>
+          <PostItem data={postData} />
+        </SwiperSlide>
+      ))}
+    </HorizontalScrollBox>
+  );
+}

--- a/src/pages/index/PostItemListSkeleton.tsx
+++ b/src/pages/index/PostItemListSkeleton.tsx
@@ -1,0 +1,21 @@
+import { Box } from '../../components/Box';
+import HorizontalScrollBox from '../../components/HorizontalScrollBox';
+import { SwiperSlide } from 'swiper/react';
+
+export default function PostItemsSkeleton() {
+  return (
+    <HorizontalScrollBox>
+      {Array.from({ length: 2 }).map((_, index) => (
+        <SwiperSlide>
+          <Box
+            key={index}
+            className="skeleton_loading h-[17rem] w-[17rem] flex-col overflow-hidden p-0"
+          >
+            <div className="h-[17rem]" />
+            <div className="box-border h-[4rem] bg-white" />
+          </Box>
+        </SwiperSlide>
+      ))}
+    </HorizontalScrollBox>
+  );
+}

--- a/src/pages/index/PostSection.tsx
+++ b/src/pages/index/PostSection.tsx
@@ -18,8 +18,8 @@ export const PostSection = () => {
                 <PostItem data={postData} />
               </SwiperSlide>
             ))
-          : Array.from({ length: 2 }).map(() => (
-              <SwiperSlide>
+          : Array.from({ length: 2 }).map((_, index) => (
+              <SwiperSlide key={`post-${index}`}>
                 <Box className="skeleton_loading h-[17rem] w-[17rem] flex-col p-0">
                   <div className="h-[17rem]" />
                   <div className="h-[4rem] bg-white" />

--- a/src/pages/index/PostSection.tsx
+++ b/src/pages/index/PostSection.tsx
@@ -4,18 +4,28 @@ import { PostItem } from './PostItem';
 import { Section } from './Section';
 import { useGetPostList } from '../../query-hooks/post';
 import { PostDetailResponse } from '../../api/post/types';
+import { Box } from '../../components/Box';
 
 export const PostSection = () => {
-  const { data: postList } = useGetPostList('');
+  const { data: postList, isFetched } = useGetPostList('');
 
   return (
     <Section title="게시글 둘러보기">
       <HorizontalScrollBox>
-        {postList?.content.map((postData: PostDetailResponse) => (
-          <SwiperSlide key={`post-${postData.postId}`}>
-            <PostItem data={postData} />
-          </SwiperSlide>
-        ))}
+        {isFetched
+          ? postList?.content.map((postData: PostDetailResponse) => (
+              <SwiperSlide key={`post-${postData.postId}`}>
+                <PostItem data={postData} />
+              </SwiperSlide>
+            ))
+          : Array.from({ length: 2 }).map(() => (
+              <SwiperSlide>
+                <Box className="skeleton_loading h-[17rem] w-[17rem] flex-col p-0">
+                  <div className="h-[17rem]" />
+                  <div className="h-[4rem] bg-white" />
+                </Box>
+              </SwiperSlide>
+            ))}
       </HorizontalScrollBox>
     </Section>
   );

--- a/src/pages/index/PostSection.tsx
+++ b/src/pages/index/PostSection.tsx
@@ -1,32 +1,14 @@
-import { SwiperSlide } from 'swiper/react';
-import HorizontalScrollBox from '../../components/HorizontalScrollBox';
-import { PostItem } from './PostItem';
+import { Suspense, lazy } from 'react';
 import { Section } from './Section';
-import { useGetPostList } from '../../query-hooks/post';
-import { PostDetailResponse } from '../../api/post/types';
-import { Box } from '../../components/Box';
+import PostItemListSkeleton from './PostItemListSkeleton';
+const PostItemList = lazy(() => import('./PostItemList'));
 
 export const PostSection = () => {
-  const { data: postList, isFetched } = useGetPostList('');
-
   return (
     <Section title="게시글 둘러보기">
-      <HorizontalScrollBox>
-        {isFetched
-          ? postList?.content.map((postData: PostDetailResponse) => (
-              <SwiperSlide key={`post-${postData.postId}`}>
-                <PostItem data={postData} />
-              </SwiperSlide>
-            ))
-          : Array.from({ length: 2 }).map((_, index) => (
-              <SwiperSlide key={`post-${index}`}>
-                <Box className="skeleton_loading h-[17rem] w-[17rem] flex-col p-0">
-                  <div className="h-[17rem]" />
-                  <div className="h-[4rem] bg-white" />
-                </Box>
-              </SwiperSlide>
-            ))}
-      </HorizontalScrollBox>
+      <Suspense fallback={<PostItemListSkeleton />}>
+        <PostItemList />
+      </Suspense>
     </Section>
   );
 };

--- a/src/query-hooks/post/index.ts
+++ b/src/query-hooks/post/index.ts
@@ -1,9 +1,13 @@
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import {
+  useInfiniteQuery,
+  useQuery,
+  useSuspenseQuery,
+} from '@tanstack/react-query';
 import { Post } from '../../api/post';
 import { FilterCategory } from '../../types/news-category';
 
 export const useGetPostList = (category: string) =>
-  useQuery({
+  useSuspenseQuery({
     queryFn: () => Post.getPostList(category),
     queryKey: ['postList'],
   });

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -82,6 +82,20 @@ input[type='password'] {
     #ffffff;
 }
 
+/* Skeleton */ 
+.skeleton_loading {
+  background: linear-gradient(120deg, #e5e5e5 30%, #f0f0f0 38%, #f0f0f0 40%, #e5e5e5 48%);
+  background-size: 200% 100%;
+  background-position: 100% 0;
+  animation: load 1s infinite;
+}
+
+@keyframes load {
+  100% {
+      background-position: -100% 0;
+  }
+}
+
 /* Swiper */
 .swiper-slide {
   display: flex;


### PR DESCRIPTION
## 📝  What is this PR?
메인 화면 접속시 최신 글 목록을 불러오는데 fetch 후에 컴포넌트가 렌더링되므로, Layout Shift가 발생됩니다.
이를 해결하기 위해 `Suspense`와 `lazy`를 통하여 fallback으로 Skeleton 컴포넌트를 표시하도록 하였습니다.
<br/>

## ✅ Changes
- dynamic import를 통하여 Route마다 fallback으로 `Loader` 컴포넌트를 보여줬으나, 라우터 전환시 페이지 렌더링 속도가 대체로 느리지 않다고 판단하여, fallback 값을 `null`로 수정하였습니다.
- 처음에 `useQuery`의 `isFetched`에 따라 Skeleton을 표시하였으나, `useSuspenseQuery`가 있는 것을 확인하고, `Suspense`를 사용하였습니다.
<br/>

## 🎉 Result
Layout Shift 현상을 해결하였고, Skeleton UI를 통하여 더 나은 사용자 경험을 제공할 수 있게 되었습니다.
| Before        | After                         | 
| ----------- | ---------------------------- | 
| ![Honeycam 2024-07-20 00-46-30](https://github.com/user-attachments/assets/b7cd2d62-4b22-41f2-9225-4f70bc2e9238) | ![Honeycam 2024-07-20 00-38-31](https://github.com/user-attachments/assets/56d6b65e-d469-4c30-9d05-e6e285bd6b14)   | 




<br/>
